### PR TITLE
Deprecation warning positionalParams in extend()

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ This way a codebase can be gradually brought into compliance over time.
 
 `disallowEmberView` will warn you if you use the deprecated `Ember.View`, `Ember.LinkView`, `Ember.Select`, `Ember.ContainerView`, or `Ember.CollectionView` classes. See http://emberjs.com/deprecations/v1.x/#toc_ember-view for details.
 
+`disallowPositionalParamsExtend` will warn you if you use `positionalParams`
+within `.extend()` instead of setting it as a static property on the class
+itself. See http://emberjs.com/deprecations/v1.x/#toc_set-code-positionalparams-code-as-a-static-property-on-the-class for details.
+
 ### Other Ember best practices
 
 `disallowPrototypeExtension` will warn you if you are using `.property()`, `.observes()` or `observesBefore()`. See http://guides.emberjs.com/v1.10.0/configuring-ember/disabling-prototype-extensions/#toc_functions for details.

--- a/lib/helpers/ember-core.js
+++ b/lib/helpers/ember-core.js
@@ -91,7 +91,7 @@ module.exports.prototype.findExtendBlocks = function() {
   }
 
   this.file.iterateNodesByType(['CallExpression'], function(node) {
-    if (node.callee.property.name !== 'extend') {
+    if (node.callee.property.name !== 'extend' || node.arguments.length === 0) {
       return;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,4 +12,5 @@ module.exports = function(configuration) {
   configuration.registerRule(require('./rules/disallow-emberkeys'));
   configuration.registerRule(require('./rules/disallow-emberoneway'));
   configuration.registerRule(require('./rules/disallow-emberview'));
+  configuration.registerRule(require('./rules/disallow-positionalparams-extend'));
 };

--- a/lib/rules/disallow-positionalparams-extend.js
+++ b/lib/rules/disallow-positionalparams-extend.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+var EmberCoreHelpers = require('../helpers/ember-core');
+
+module.exports = function() {};
+
+module.exports.prototype.getOptionName = function() {
+  return 'disallowPositionalParamsExtend';
+};
+
+module.exports.prototype.configure = function(options) {
+  assert(
+    options === true,
+    this.getOptionName() + ' option requires a true value or should be removed'
+  );
+};
+
+module.exports.prototype.check = function(file, errors) {
+  var ember = new EmberCoreHelpers(file);
+  ember.findExtendBlocksProperties('positionalParams').forEach(function(prop) {
+    errors.add(
+      'positionalParams within .extend() is deprecated in Ember 1.13',
+      prop.loc.start
+    );
+  });
+};

--- a/test/lib/rules/disallow-positionalparams-extend.js
+++ b/test/lib/rules/disallow-positionalparams-extend.js
@@ -1,0 +1,47 @@
+describe('lib/rules/disallow-positionalparams-extend', function () {
+    var checker = global.checker({
+        plugins: ['./lib/index']
+    });
+
+    describe('not configured', function() {
+
+      it('should report with undefined', function() {
+        global.expect(function() {
+          checker.configure({disallowPositionalParamsExtend: undefined});
+        }).to.throws(/requires a true value/i);
+      });
+
+      it('should report with an object', function() {
+        global.expect(function() {
+          checker.configure({disallowPositionalParamsExtend: {}});
+        }).to.throws(/requires a true value/i);
+      });
+
+    });
+
+    describe('with true', function() {
+      checker.rules({disallowPositionalParamsExtend: true});
+
+      checker.cases([
+        /* jshint ignore:start */
+        {
+          it: 'should not report reopened class',
+          code: function() {
+            var Thing = Ember.Component.extend();
+            //Thing.reopenClass({
+            //  positionalParams: [ 'a', 'b' ]
+            //});
+          }
+        }, {
+          it: 'should report deprecated use',
+          errors: 1,
+          code: function() {
+            Ember.Component.extend({
+              positionalParams: [ 'a', 'b' ]
+            });
+          }
+        }
+        /* jshint ignore:end */
+      ]);
+    });
+});

--- a/test/lib/rules/disallow-positionalparams-extend.js
+++ b/test/lib/rules/disallow-positionalparams-extend.js
@@ -28,9 +28,9 @@ describe('lib/rules/disallow-positionalparams-extend', function () {
           it: 'should not report reopened class',
           code: function() {
             var Thing = Ember.Component.extend();
-            //Thing.reopenClass({
-            //  positionalParams: [ 'a', 'b' ]
-            //});
+            Thing.reopenClass({
+              positionalParams: [ 'a', 'b' ]
+            });
           }
         }, {
           it: 'should report deprecated use',


### PR DESCRIPTION
Setting positionalParams within `.extend` is deprecated. It has to be set as a static property on the class itself (`.reopenClass`).

See http://emberjs.com/deprecations/v1.x/#toc_set-code-positionalparams-code-as-a-static-property-on-the-class