### PR TITLE
Automagically fix Ember.keys() to Object.keys() when `--fix` is employed

### DIFF
--- a/lib/helpers/deprecated-class.js
+++ b/lib/helpers/deprecated-class.js
@@ -31,10 +31,12 @@ module.exports.prototype.check = function(file, errors) {
 
   deprecatedClasses.forEach(function(clazz) {
     _this.helpers.findEmberClass(clazz).forEach(function(node) {
-      errors.add(
-        errorMap[clazz],
-        node.loc.start
-      );
+      errors.cast({
+        message: errorMap[clazz],
+        line: node.loc.start.line,
+        column: node.loc.start.column,
+        additional: node
+      });
     });
   });
 };

--- a/lib/rules/disallow-emberkeys.js
+++ b/lib/rules/disallow-emberkeys.js
@@ -18,9 +18,18 @@ module.exports.prototype.check = function(file, errors) {
   var helpers = new EmberCoreHelpers(file);
 
   helpers.findEmberFunction('keys', 0).forEach(function(node) {
-    errors.add(
-      'Ember.keys is deprecated in Ember 1.13',
-      node.callee.property.loc.start
-    );
+    errors.cast({
+      message: 'Ember.keys is deprecated in Ember 1.13',
+      line: node.callee.property.loc.start.line,
+      column: node.callee.property.loc.start.column,
+      additional: node
+    });
   });
+};
+
+module.exports.prototype._fix = function(file, error) {
+  var node = error.additional;
+  var token = file.getFirstNodeToken(node);
+
+  token.value = 'Object';
 };

--- a/test/init.js
+++ b/test/init.js
@@ -133,6 +133,10 @@ function rulesChecker(opts) {
      */
     check: function(str) {
       return checker.checkString(str);
+    },
+
+    fixString: function(str) {
+      return checker.fixString(str);
     }
   };
 }

--- a/test/lib/rules/disallow-emberkeys.js
+++ b/test/lib/rules/disallow-emberkeys.js
@@ -1,3 +1,5 @@
+var expect = require('chai').expect;
+
 describe('lib/rules/disallow-embertrycatch', function () {
     var checker = global.checker({
         plugins: ['./lib/index']
@@ -50,5 +52,10 @@ describe('lib/rules/disallow-embertrycatch', function () {
         }
         /* jshint ignore:end */
       ]);
+
+      it('fixed to Object.keys()', function() {
+        var result = checker.fixString("Ember.keys({})");
+        expect(result.output).to.equal("Object.keys({})");
+      });
     });
 });


### PR DESCRIPTION
This is getting dangerously close to `ember-watson` (https://github.com/abuiles/ember-watson), but some of these deprecations are mechanical to fix, and it might be nice to support the `--fix` switch to re-write the AST when requested.

@rwjblue Any thoughts?