### PR TITLE
Add support for app.container.lookup() deprecation

### DIFF
--- a/.integration_jscsrc
+++ b/.integration_jscsrc
@@ -29,5 +29,6 @@
   "disallowHandlebarsHelpers": true,
   "disallowInitializerArity": true,
   "disallowPrivateRegistryProperty": true,
+  "disallowAppInstanceContainer": true,
   "disallowPrototypeExtension": true
 }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ None. Ember 2.0 removed support for the above deprecations.
 
 - `disallowPrivateRegistryProperty` will warn you if you use one of the private `app.registry.*` deprecations. See http://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry for details.
 
-- `disallowAppInstanceContainer` will warn you if you use the private `app.container.lookup()` depreprecation in an initializer. See http://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry for details.
+- `disallowAppInstanceContainer` will warn you if you use the private `app.container.lookup()` depreprecation in an initializer. See http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container for details.
 
 ### Other Ember best practices
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ None. Ember 2.0 removed support for the above deprecations.
 
 - `disallowPrivateRegistryProperty` will warn you if you use one of the private `app.registry.*` deprecations. See http://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry for details.
 
+- `disallowAppInstanceContainer` will warn you if you use the private `app.container.lookup()` depreprecation in an initializer. See http://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry for details.
+
 ### Other Ember best practices
 
 - `disallowPrototypeExtension` will warn you if you are using `.property()`, `.observes()` or `observesBefore()`. See http://guides.emberjs.com/v1.10.0/configuring-ember/disabling-prototype-extensions/#toc_functions for details.

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,4 +24,5 @@ module.exports = function(configuration) {
   configuration.registerRule(require('./rules/disallow-handlebarshelpers'));
   configuration.registerRule(require('./rules/disallow-initializerarity'));
   configuration.registerRule(require('./rules/disallow-privateregistryproperty'));
+  configuration.registerRule(require('./rules/disallow-appinstancecontainer'));
 };

--- a/lib/rules/disallow-appinstancecontainer.js
+++ b/lib/rules/disallow-appinstancecontainer.js
@@ -43,9 +43,6 @@ module.exports.prototype.check = function(file, errors) {
       }
 
       file.iterateNodesByType('MemberExpression', function(member) {
-        if (!member.object) {
-          return;
-        }
         var variable = member.object;
 
         if (variable.name === appInstance.name) {

--- a/lib/rules/disallow-appinstancecontainer.js
+++ b/lib/rules/disallow-appinstancecontainer.js
@@ -1,0 +1,64 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype.getOptionName = function() {
+  return 'disallowAppInstanceContainer';
+};
+
+module.exports.prototype.configure = function(options) {
+  assert(
+    options === true || options === false,
+    this.getOptionName() + ' option requires a true value or should be removed'
+  );
+};
+
+module.exports.prototype.check = function(file, errors) {
+  if (file.getFilename().indexOf('initializer') < 0) {
+    return;
+  }
+
+  file.iterateNodesByType('Property', function(node) {
+    if (node.key.name !== 'initialize') {
+      return;
+    }
+
+    if (node.value.type === 'Identifier') {
+      // this is a reference to a declared variable
+      var identifier = node.value.name;
+
+      file.iterateNodesByType('Identifier', function(variable) {
+        if (variable.name === identifier && variable.parentNode.init) {
+          node = variable.parentNode.init;
+        }
+      });
+    } else {
+      node = node.value;
+    }
+
+    if (node.type === 'FunctionExpression') {
+      var appInstance = node.params[0];
+      if (!appInstance) {
+        return;
+      }
+
+      file.iterateNodesByType('MemberExpression', function(member) {
+        if (!member.object) {
+          return;
+        }
+        var variable = member.object;
+
+        if (variable.name === appInstance.name) {
+          if (member.property.name === 'container') {
+            errors.cast({
+              message: 'application.container.lookup is deprecated in Ember 2.1',
+              line: member.property.loc.start.line,
+              column: member.property.loc.start.column,
+              additional: member.property
+            });
+          }
+        }
+      });
+    }
+  });
+};

--- a/test/lib/rules/disallow-appinstancecontainer.js
+++ b/test/lib/rules/disallow-appinstancecontainer.js
@@ -1,0 +1,62 @@
+describe('lib/rules/disallow-appinstancecontainer', function () {
+    var checker = global.checker({
+        plugins: ['./lib/index']
+    });
+
+    describe('not configured', function() {
+
+      it('should report with undefined', function() {
+        global.expect(function() {
+          checker.configure({disallowAppInstanceContainer: undefined});
+        }).to.throws(/requires a true value/i);
+      });
+
+      it('should report with an object', function() {
+        global.expect(function() {
+          checker.configure({disallowAppInstanceContainer: {}});
+        }).to.throws(/requires a true value/i);
+      });
+
+    });
+
+    describe('with true', function() {
+      checker.rules({disallowAppInstanceContainer: true});
+
+      checker.cases([
+        /* jshint ignore:start */
+        {
+          it: 'should not report appinstance.lookup',
+          filename: 'app/initializer/foo.js',
+          code: function() {
+            var initialize = function(appInstance) {
+              var store = appInstance.lookup('service:store');
+
+              store.pushPayload('<payload here>');
+            }
+
+            return {
+              name: 'preload-store',
+              initialize: initialize
+            }
+          }
+        }, {
+          it: 'should report appinstance.container',
+          filename: 'app/initializer/foo.js',
+          errors: 1,
+          code: function() {
+            var initialize = function(appInstance) {
+              var store = appInstance.container.lookup('service:store');
+
+              store.pushPayload('<payload here>');
+            }
+
+            return {
+              name: 'preload-store',
+              initialize: initialize
+            }
+          }
+        }
+        /* jshint ignore:end */
+      ]);
+    });
+});

--- a/test/lib/rules/disallow-appinstancecontainer.js
+++ b/test/lib/rules/disallow-appinstancecontainer.js
@@ -40,6 +40,44 @@ describe('lib/rules/disallow-appinstancecontainer', function () {
             }
           }
         }, {
+          it: 'should not report appinstance.container in non-initializer path',
+          filename: 'app/bar/foo.js',
+          code: function() {
+            var initialize = function(appInstance) {
+              var store = appInstance.container.lookup('service:store');
+
+              store.pushPayload('<payload here>');
+            }
+
+            return {
+              name: 'preload-store',
+              initialize: initialize
+            }
+          }
+        }, {
+          it: 'should not report empty params',
+          filename: 'app/initializer/foo.js',
+          code: function() {
+            var initialize = function() {
+            }
+
+            return {
+              name: 'preload-store',
+              initialize: initialize
+            }
+          }
+        }, {
+          it: 'should not report anonymous initializer',
+          filename: 'app/initializer/foo.js',
+          code: function() {
+            return {
+              name: 'inject-session',
+              initialize: function(application) {
+                application.lookup('service:session');
+              }
+            }
+          }
+        }, {
           it: 'should report appinstance.container',
           filename: 'app/initializer/foo.js',
           errors: 1,
@@ -53,6 +91,18 @@ describe('lib/rules/disallow-appinstancecontainer', function () {
             return {
               name: 'preload-store',
               initialize: initialize
+            }
+          }
+        }, {
+          it: 'should report anonymous initializer',
+          filename: 'app/initializer/foo.js',
+          errors: 1,
+          code: function() {
+            return {
+              name: 'inject-session',
+              initialize: function(application) {
+                application.container.lookup('service:session');
+              }
             }
           }
         }


### PR DESCRIPTION
See https://github.com/minichate/jscs-ember-deprecations/issues/2
