### PR TITLE
Adding `disallowInjectedContainerAccess` to warn about Ember 2.3 deprecations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ None. Ember 2.0 removed support for the above deprecations.
 
 - `disallowPrototypeExtension` will warn you if you are using `.property()`, `.observes()` or `observesBefore()`. See http://guides.emberjs.com/v1.10.0/configuring-ember/disabling-prototype-extensions/#toc_functions for details.
 
-# Licence
+### Deprecations added in Ember 2.3
+
+- `disallowInjectedContainerAccess` will warn you if you are using the injected container (`this.container`). See http://emberjs.com/deprecations/v2.x/#toc_injected-container-access for details.
+
+# License
 
 This library is lovingly brought to you by [@minichate](https://twitter.com/minichate). It is released under the MIT license.

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,4 +29,5 @@ module.exports = function(configuration) {
   configuration.registerRule(require('./rules/disallow-defaultlayout'));
   configuration.registerRule(require('./rules/disallow-currentstate'));
   configuration.registerRule(require('./rules/disallow-dual-getter-setter'));
+  configuration.registerRule(require('./rules/disallow-injectedcontaineraccess'));
 };

--- a/lib/rules/disallow-injectedcontaineraccess.js
+++ b/lib/rules/disallow-injectedcontaineraccess.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype.getOptionName = function() {
+  return 'disallowInjectedContainerAccess';
+};
+
+module.exports.prototype.configure = function(options) {
+  assert(
+    options === true || options === false,
+    this.getOptionName() + ' option requires a boolean value or should be removed'
+  );
+};
+
+module.exports.prototype.check = function(file, errors) {
+  file.iterateNodesByType('Identifier', function(node) {
+    if (node.name === 'container' &&
+       (node.parentNode && node.parentNode.object &&  node.parentNode.object.type === 'ThisExpression')) {
+      errors.cast({
+        message: '.container has been deprecated as of Ember 2.3. Use Ember.getOwner(this) instead.',
+        line: node.parentNode.loc.start.line,
+        column: node.parentNode.loc.start.column,
+        additional: node
+      });
+    }
+  });
+};

--- a/test/lib/rules/disallow-injectedcontaineraccess.js
+++ b/test/lib/rules/disallow-injectedcontaineraccess.js
@@ -1,0 +1,58 @@
+describe('lib/rules/disallow-injectedcontaineraccess', function () {
+    var checker = global.checker({
+        plugins: ['./lib/index']
+    });
+
+    describe('not configured', function() {
+
+      it('should report with undefined', function() {
+        global.expect(function() {
+          checker.configure({disallowInjectedContainerAccess: undefined});
+        }).to.throws(/requires a boolean value/i);
+      });
+
+      it('should report with an object', function() {
+        global.expect(function() {
+          checker.configure({disallowInjectedContainerAccess: {}});
+        }).to.throws(/requires a boolean value/i);
+      });
+
+    });
+
+    describe('with true', function() {
+      checker.rules({disallowInjectedContainerAccess: true});
+
+      checker.cases([
+        /* jshint ignore:start */
+        {
+          it: 'should not report on similar container Identifiers',
+          filename: 'app/component/x-foo.js',
+          code: function() {
+            var XFooComponent = Ember.Component.extend({
+              init: function() {
+                this._supezr();
+                var x = {}, container = {};
+                this.customThingOne = this.myContainer.lookup('custom:thing');
+                this.customThingTwo = x.container.lookup('custom:thing');
+                this.customThingThree = container.lookup('custom:thing');
+              }
+            });
+          }
+        },
+        {
+          it: 'should report deprecation this.container',
+          errors: 1,
+          filename: 'app/component/x-foo.js',
+          code: function() {
+            var XFooComponent = Ember.Component.extend({
+              init: function() {
+                this._super();
+                this.customThing = this.container.lookup('custom:thing');
+              }
+            });
+          }
+        }
+        /* jshint ignore:end */
+      ]);
+    });
+});


### PR DESCRIPTION
Also resolves #4.

This is my first time ever working with JSCS or ESTrees so it's very possible there is a better way to handle this. Willing to take any feedback.

Also, it seems counter intuitive to start with the Ember 2.3 deprecation (instead of the outstanding Ember 2.2), but that one seems very hard, possibly impossible. I will comment further on that story.  